### PR TITLE
Install multilib versions of gcc

### DIFF
--- a/utils/pipeline/README.md
+++ b/utils/pipeline/README.md
@@ -65,7 +65,7 @@ __dependency__
 
 For Ubuntu 18.04, we use `apt` to install dependencies:
 ```
-apt install git subversion cmake gcc g++ clang llvm-8 re2c z3
+apt install git subversion cmake gcc-multilib g++-multilib clang llvm-8 re2c z3
 ```
 
 __slumps__


### PR DESCRIPTION
Otherwise, in `run-length_encoding.c` the `clang -emit-llvm …` step fails with:

```
/usr/include/stdio.h:27:10: fatal error: 'bits/libc-header-start.h' file not found
#include <bits/libc-header-start.h>
```

The missing file belongs to `libc6-dev-i386` but installing the `-multilib` version of gcc is simpler and more fool-proof.